### PR TITLE
dc/13 keys v2

### DIFF
--- a/read_encrypted.py
+++ b/read_encrypted.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from solidpod_helper import (
     gen_master_key,
     gen_verify_key,
+    derive_keys,
     decrypt,
     parse_ttl,
     path_pred,
@@ -17,6 +18,8 @@ from solidpod_helper import (
     indi_key_pred,
     inherit_key_pred,
     enc_data_pred,
+    key_version_pred,
+    salt_pred,
     server_path,
 )
 
@@ -38,14 +41,24 @@ if __name__ == '__main__':
     relative_file_path = '/'.join(items[1:])
 
     security_key_str = getpass(prompt='Security Key: ')
-    master_key = gen_master_key(security_key_str)
-    verify_key = gen_verify_key(security_key_str)
 
     # Verify security key
 
     enc_key_map = parse_ttl(f'{app_path}/encryption/enc-keys.ttl')
-    verify_key_stored = list(enc_key_map.items())[0][1][verify_key_pred]
-    if verify_key.decode('utf-8') != verify_key_stored:
+    enc_key_entry = list(enc_key_map.items())[0][1]
+
+    # Derive keys as per solidpod: v2 or legacy
+
+    if key_version_pred in enc_key_entry:
+        assert salt_pred in enc_key_entry
+        salt = b64decode(enc_key_entry[salt_pred])
+        master_key, verify_key = derive_keys(security_key_str, salt)
+    else:
+        master_key = gen_master_key(security_key_str)
+        verify_key = gen_verify_key(security_key_str).decode('utf-8')
+
+    verify_key_stored = enc_key_entry[verify_key_pred]
+    if verify_key != verify_key_stored:
         print('ERROR: Incorrect security key (verification failed).')
         sys.exit(0)
 

--- a/solidpod_helper.py
+++ b/solidpod_helper.py
@@ -9,7 +9,7 @@ from rdflib import (
     URIRef,
 )
 from urllib.parse import urlparse
-from argon2.low_level import hash_secret_raw, Type
+from argon2.low_level import hash_secret_raw, Type  # argon2-cffi
 from Cryptodome.Cipher import AES
 from Cryptodome.Hash import SHA256
 from Cryptodome.Protocol.KDF import HKDF

--- a/solidpod_helper.py
+++ b/solidpod_helper.py
@@ -9,7 +9,10 @@ from rdflib import (
     URIRef,
 )
 from urllib.parse import urlparse
+from argon2.low_level import hash_secret_raw, Type
 from Cryptodome.Cipher import AES
+from Cryptodome.Hash import SHA256
+from Cryptodome.Protocol.KDF import HKDF
 from Cryptodome.Random import get_random_bytes
 from Cryptodome.Util.Padding import (
     pad,
@@ -24,6 +27,8 @@ private_key_pred = 'prvKey'
 indi_key_pred = 'sessionKey'
 enc_data_pred = 'encData'
 inherit_key_pred = 'inheritKeyFrom'
+key_version_pred = 'keyVersion'
+salt_pred = 'salt'
 server_path = '/opt/solid/server/'
 apps_terms = 'https://solidcommunity.au/predicates/terms#';
 
@@ -65,6 +70,35 @@ def gen_master_key(security_key_str):
 def gen_verify_key(security_key_str):
     # Generate verification key from security key string as per `solidpod`
     return hashlib.sha224(security_key_str.encode('utf-8')).hexdigest()[:32].encode('utf-8')
+
+def derive_keys(security_key_str, salt):
+    # Derive the master key and verification key from the security key
+    # string as per `solidpod`'s (version 2) `deriveKeys`.
+    #
+    # Runs Argon2id once (the expensive, salted step) to obtain a master
+    # secret, then HKDF-expands it into two domain-separated outputs: the
+    # AES-256 master key and the verification value stored on the POD.
+    # - security_key_str (str): user-provided security key
+    # - salt (bytes): 16-byte key-derivation salt, also reused as the HKDF
+    #   salt (the two outputs are separated by distinct `info` labels, not
+    #   by the salt/nonce)
+    # Returns (master_key, verification_key):
+    # - master_key (bytes): 32-byte AES-256 key
+    # - verification_key (str): base64-encoded 32-byte verification value
+    master_secret = hash_secret_raw(
+        secret=security_key_str.encode('utf-8'),
+        salt=salt,
+        time_cost=1,       # iterations
+        memory_cost=10000, # 10,000 x 1kB = 10 MB
+        parallelism=4,
+        hash_len=32,
+        type=Type.ID,
+    )
+
+    master_key = HKDF(master_secret, 32, salt, SHA256, context=b'solidpod/v2/master-key')
+    verification_key_bytes = HKDF(master_secret, 32, salt, SHA256, context=b'solidpod/v2/verification')
+
+    return master_key, b64encode(verification_key_bytes).decode('ascii')
 
 def encrypt(data_str, key, iv):
     # Encrypt the input string `data_str` using AES with


### PR DESCRIPTION
Support both the legacy and [version 2](https://github.com/anusii/solidpod/blob/d16a20e1e2126e1466c0f866e8f8cbce8eea715e/lib/src/solid/utils/key_helper.dart#L91) key derivation mechanisms used in solidpod.

Resolved #13.

Tested:
- Run `read_encrypted.py` on `dev.empwr.au` where the required python package [argon2-cffi](https://pypi.org/project/argon2-cffi/) is installed.